### PR TITLE
feat: add skip-to-content link for keyboard accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-08-17 - [Skip-to-content Layout Enhancements]
+**Learning:** Implementing skip-to-content links often requires pairing them with a proper semantic `<main>` tag that has `tabindex="-1"` and `outline-none` so focus skips down securely without leaving confusing focus rings.
+**Action:** Ensure all site wrappers have skip-to-content logic utilizing this `<main>` pairing rather than just skipping to generic `id` anchors.

--- a/dev_server.log
+++ b/dev_server.log
@@ -1,0 +1,19 @@
+
+> uodpa@0.0.1 dev
+> astro dev
+
+18:14:01 [vite] connected.
+18:14:03 [types] Generated 1ms
+18:14:03 [vite] connected.
+
+ update  ▶ New version of Astro available: 7.2.2
+  Run npx @astrojs/upgrade to update
+
+18:14:03 [content] Syncing content
+18:14:03 [content] Synced content
+18:14:03 [vite] Re-optimizing dependencies because vite config has changed
+ astro  v7.1.1 ready in 3781 ms
+┃ Local    http://localhost:4321/
+┃ Network  use --host to expose
+18:14:04 watching for file changes...
+18:14:29 [200] / 106ms

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -51,11 +51,14 @@ const canonicalPath = locale === "fr" ? frenchPath : englishPath;
 		/>
 	</head>
 	<body class="flex min-h-screen flex-col bg-background text-quaternary antialiased">
+		<a href="#main-content" class="absolute left-4 top-4 z-50 -translate-y-[150%] rounded-md bg-primary px-4 py-2 font-bold text-white transition-transform focus:translate-y-0 focus:outline-none focus:ring-2 focus:ring-tertiary focus:ring-offset-2">
+			{locale === "fr" ? "Passer au contenu principal" : "Skip to main content"}
+		</a>
 		<div class="pointer-events-none fixed inset-0 -z-10 bg-[radial-gradient(circle_at_10%_10%,rgba(20,93,160,0.16),transparent_35%),radial-gradient(circle_at_85%_15%,rgba(92,27,109,0.12),transparent_30%),radial-gradient(circle_at_50%_100%,rgba(140,6,6,0.12),transparent_35%)]"></div>
 		<Navbar locale={locale} />
-		<div class="flex-1 py-6">
+		<main id="main-content" tabindex="-1" class="flex-1 py-6 outline-none">
 			<slot />
-		</div>
+		</main>
 		<Footer locale={locale} />
 	</body>
 </html>


### PR DESCRIPTION
💡 What: Added a skip-to-content link in `Layout.astro` and wrapped the layout slot in a semantic `<main>` tag with programmatic focus setup.
🎯 Why: Allows keyboard-only and screen reader users to bypass the navigation bar and jump directly to the main content.
♿ Accessibility: Improves keyboard navigation with standard focus patterns (hide offscreen, show on focus) and uses `tabindex="-1"` and `outline-none` on the main wrapper to securely catch the programmatic focus without causing confusing focus rings.

---
*PR created automatically by Jules for task [6778420511077461644](https://jules.google.com/task/6778420511077461644) started by @arcanistzed*